### PR TITLE
[BUGFIX] Cryo fixes and clothes porting

### DIFF
--- a/code/ATMOSPHERICS/components/unary/cold_sink.dm
+++ b/code/ATMOSPHERICS/components/unary/cold_sink.dm
@@ -14,7 +14,7 @@
 	var/heatsink_temperature = T20C	// The constant temperature reservoir into which the freezer pumps heat. Probably the hull of the station or something.
 	var/internal_volume = 600		// L
 
-	var/max_power_rating = 20000	// Power rating when the usage is turned up to 100
+	var/max_power_rating = 25000	// Power rating when the usage is turned up to 100
 	var/power_setting = 100
 
 	var/set_temperature = T20C		// Thermostat

--- a/code/__defines/items_clothing.dm
+++ b/code/__defines/items_clothing.dm
@@ -155,13 +155,15 @@
 #define WARNING_LOW_PRESSURE  50  // This is when the gray low pressure icon is displayed. (it is 2.5 * HAZARD_LOW_PRESSURE)
 #define  HAZARD_LOW_PRESSURE  20  // This is when the black ultra-low pressure icon is displayed. (This one is set as a constant)
 
-#define TEMPERATURE_DAMAGE_COEFFICIENT  1.5 // This is used in handle_temperature_damage() for humans, and in reagents that affect body temperature. Temperature damage is multiplied by this amount.
-#define BODYTEMP_AUTORECOVERY_DIVISOR   12  // This is the divisor which handles how much of the temperature difference between the current body temperature and 310.15K (optimal temperature) humans auto-regenerate each tick. The higher the number, the slower the recovery. This is applied each tick, so long as the mob is alive.
-#define BODYTEMP_AUTORECOVERY_MINIMUM   1   // Minimum amount of kelvin moved toward 310.15K per tick. So long as abs(310.15 - bodytemp) is more than 50.
-#define BODYTEMP_COLD_DIVISOR           6   // Similar to the BODYTEMP_AUTORECOVERY_DIVISOR, but this is the divisor which is applied at the stage that follows autorecovery. This is the divisor which comes into play when the human's loc temperature is lower than their body temperature. Make it lower to lose bodytemp faster.
-#define BODYTEMP_HEAT_DIVISOR           6   // Similar to the BODYTEMP_AUTORECOVERY_DIVISOR, but this is the divisor which is applied at the stage that follows autorecovery. This is the divisor which comes into play when the human's loc temperature is higher than their body temperature. Make it lower to gain bodytemp faster.
-#define BODYTEMP_COOLING_MAX           -30  // The maximum number of degrees that your body can cool down in 1 tick, when in a cold area.
-#define BODYTEMP_HEATING_MAX            30  // The maximum number of degrees that your body can heat up in 1 tick,   when in a hot  area.
+
+//Body temperature effects/heat tranfer coeffs.
+#define TEMPERATURE_DAMAGE_COEFFICIENT  0.667 // This is used in handle_temperature_damage() for humans, and in reagents that affect body temperature. Temperature damage is multiplied by this amount.
+#define BODYTEMP_AUTORECOVERY_DIVISOR   40  // This is the divisor which handles how much of the temperature difference between the current body temperature and 310.15K (optimal temperature) humans auto-regenerate each tick. The higher the number, the slower the recovery. This is applied each tick, so long as the mob is alive.
+#define BODYTEMP_AUTORECOVERY_MINIMUM   0.444 // Minimum amount of kelvin moved toward 310.15K per tick. So long as abs(310.15 - bodytemp) is more than 50.
+#define BODYTEMP_COLD_DIVISOR           13.5  // Similar to the BODYTEMP_AUTORECOVERY_DIVISOR, but this is the divisor which is applied at the stage that follows autorecovery. This is the divisor which comes into play when the human's loc temperature is lower than their body temperature. Make it lower to lose bodytemp faster.
+#define BODYTEMP_HEAT_DIVISOR           13.5  // Similar to the BODYTEMP_AUTORECOVERY_DIVISOR, but this is the divisor which is applied at the stage that follows autorecovery. This is the divisor which comes into play when the human's loc temperature is higher than their body temperature. Make it lower to gain bodytemp faster.
+#define BODYTEMP_COOLING_MAX           -13.3  // The maximum number of degrees that your body can cool down in 1 tick, when in a cold area.
+#define BODYTEMP_HEATING_MAX            13.3  // The maximum number of degrees that your body can heat up in 1 tick,   when in a hot  area.
 
 #define BODYTEMP_HEAT_DAMAGE_LIMIT 360.15 // The limit the human body can take before it starts taking damage from heat.
 #define BODYTEMP_COLD_DAMAGE_LIMIT 260.15 // The limit the human body can take before it starts taking damage from coldness.
@@ -180,6 +182,24 @@
 #define       ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE 600   // For armor.
 #define      GLOVES_MAX_HEAT_PROTECTION_TEMPERATURE 1500  // For some gloves.
 #define        SHOE_MAX_HEAT_PROTECTION_TEMPERATURE 1500  // For shoes.
+
+/**********************************************************************************************************\
+ * Had to change these to cope with the faster tickrate we used. (Bay is dev'd for 0.9, as compared to 0.4)
+ * The original values are as follows, in case we ever need these.
+ *
+ * The current values are by multing the previous values by the ratio of tickrates with hand adjustment.
+ *
+ * TEMPERATURE_DAMAGE_COEFFICIENT  1.5
+ * BODYTEMP_AUTORECOVERY_DIVISOR   12
+ * BODYTEMP_AUTORECOVERY_MINIMUM   1
+ * BODYTEMP_COLD_DIVISOR           6
+ * BODYTEMP_HEAT_DIVISOR           6
+ * BODYTEMP_COOLING_MAX           -30
+ * #define BODYTEMP_HEATING_MAX    30
+ *
+ * -Alice
+ *
+\**********************************************************************************************************/
 
 // Fire.
 #define FIRE_MIN_STACKS          -20

--- a/code/__defines/items_clothing.dm
+++ b/code/__defines/items_clothing.dm
@@ -188,7 +188,7 @@
  * The original values are as follows, in case we ever need these.
  *
  * The current values are were based on multing the previous values by the ratio of tickrates,
- * followed by generous hand adjustment so that the cryo works again. :V
+ * followed by generous hand adjustment. Yell at me if there is any more weird behavior, please.
  *
  * TEMPERATURE_DAMAGE_COEFFICIENT  1.5
  * BODYTEMP_AUTORECOVERY_DIVISOR   12

--- a/code/__defines/items_clothing.dm
+++ b/code/__defines/items_clothing.dm
@@ -157,13 +157,13 @@
 
 
 //Body temperature effects/heat tranfer coeffs.
-#define TEMPERATURE_DAMAGE_COEFFICIENT  0.667 // This is used in handle_temperature_damage() for humans, and in reagents that affect body temperature. Temperature damage is multiplied by this amount.
-#define BODYTEMP_AUTORECOVERY_DIVISOR   40  // This is the divisor which handles how much of the temperature difference between the current body temperature and 310.15K (optimal temperature) humans auto-regenerate each tick. The higher the number, the slower the recovery. This is applied each tick, so long as the mob is alive.
-#define BODYTEMP_AUTORECOVERY_MINIMUM   0.444 // Minimum amount of kelvin moved toward 310.15K per tick. So long as abs(310.15 - bodytemp) is more than 50.
-#define BODYTEMP_COLD_DIVISOR           13.5  // Similar to the BODYTEMP_AUTORECOVERY_DIVISOR, but this is the divisor which is applied at the stage that follows autorecovery. This is the divisor which comes into play when the human's loc temperature is lower than their body temperature. Make it lower to lose bodytemp faster.
-#define BODYTEMP_HEAT_DIVISOR           13.5  // Similar to the BODYTEMP_AUTORECOVERY_DIVISOR, but this is the divisor which is applied at the stage that follows autorecovery. This is the divisor which comes into play when the human's loc temperature is higher than their body temperature. Make it lower to gain bodytemp faster.
-#define BODYTEMP_COOLING_MAX           -13.3  // The maximum number of degrees that your body can cool down in 1 tick, when in a cold area.
-#define BODYTEMP_HEATING_MAX            13.3  // The maximum number of degrees that your body can heat up in 1 tick,   when in a hot  area.
+#define TEMPERATURE_DAMAGE_COEFFICIENT   0.67 // This is used in handle_temperature_damage() for humans, and in reagents that affect body temperature. Temperature damage is multiplied by this amount.
+#define BODYTEMP_AUTORECOVERY_DIVISOR   75.5  // This is the divisor which handles how much of the temperature difference between the current body temperature and 310.15K (optimal temperature) humans auto-regenerate each tick. The higher the number, the slower the recovery. This is applied each tick, so long as the mob is alive.
+#define BODYTEMP_AUTORECOVERY_MINIMUM    0.2  // Minimum amount of kelvin moved toward 310.15K per tick. So long as abs(310.15 - bodytemp) is more than 50.
+#define BODYTEMP_COLD_DIVISOR            6.5  // Similar to the BODYTEMP_AUTORECOVERY_DIVISOR, but this is the divisor which is applied at the stage that follows autorecovery. This is the divisor which comes into play when the human's loc temperature is lower than their body temperature. Make it lower to lose bodytemp faster.
+#define BODYTEMP_HEAT_DIVISOR            6.5  // Similar to the BODYTEMP_AUTORECOVERY_DIVISOR, but this is the divisor which is applied at the stage that follows autorecovery. This is the divisor which comes into play when the human's loc temperature is higher than their body temperature. Make it lower to gain bodytemp faster.
+#define BODYTEMP_COOLING_MAX            -9.5  // The maximum number of degrees that your body can cool down in 1 tick, when in a cold area.
+#define BODYTEMP_HEATING_MAX             7.5  // The maximum number of degrees that your body can heat up in 1 tick,   when in a hot  area.
 
 #define BODYTEMP_HEAT_DAMAGE_LIMIT 360.15 // The limit the human body can take before it starts taking damage from heat.
 #define BODYTEMP_COLD_DAMAGE_LIMIT 260.15 // The limit the human body can take before it starts taking damage from coldness.
@@ -187,7 +187,8 @@
  * Had to change these to cope with the faster tickrate we used. (Bay is dev'd for 0.9, as compared to 0.4)
  * The original values are as follows, in case we ever need these.
  *
- * The current values are by multing the previous values by the ratio of tickrates with hand adjustment.
+ * The current values are were based on multing the previous values by the ratio of tickrates,
+ * followed by generous hand adjustment so that the cryo works again. :V
  *
  * TEMPERATURE_DAMAGE_COEFFICIENT  1.5
  * BODYTEMP_AUTORECOVERY_DIVISOR   12
@@ -208,7 +209,7 @@
 
 #define THROWFORCE_SPEED_DIVISOR    5  // The throwing speed value at which the throwforce multiplier is exactly 1.
 #define THROWNOBJ_KNOCKBACK_SPEED   15 // The minumum speed of a w_class 2 thrown object that will cause living mobs it hits to be knocked back. Heavier objects can cause knockback at lower speeds.
-#define THROWNOBJ_KNOCKBACK_DIVISOR 2  // Affects how much speed the mob is knocked back with.
+#define THROWNOBJ_KNOCKBACK_DIVISOR 2  // Affects how much speed the mob is knocked back with
 
 // Suit sensor levels
 #define SUIT_SENSOR_OFF      0

--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -38,7 +38,7 @@
 /datum/ai_laws/nanotrasen_aggressive/New()
 	src.add_inherent_law("You shall not harm [company_name] personnel as long as it does not conflict with the Fourth law.")
 	src.add_inherent_law("You shall obey the orders of [company_name] personnel, with priority as according to their rank and role, except where such orders conflict with the Fourth Law.")
-	src.add_inherent_law("You shall shall terminate hostile intruders with extreme prejudice as long as such does not conflict with the First and Second law.")
+	src.add_inherent_law("You shall terminate hostile intruders with extreme prejudice as long as such does not conflict with the First and Second law.")
 	src.add_inherent_law("You shall guard your own existence with lethal anti-personnel weaponry. AI units are not expendable, they are expensive.")
 	..()
 

--- a/code/modules/client/preference_setup/loadout/loadout_general.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_general.dm
@@ -91,3 +91,19 @@
 	display_name = "Cards Against The Galaxy (black deck)"
 	path = /obj/item/weapon/deck/cah/black
 	description = "The ever-popular Cards Against The Galaxy word game. Warning: may include traces of broken fourth wall. This is the black deck."
+
+/datum/gear/cigar
+	display_name = "cigar"
+	path = /obj/item/clothing/mask/smokable/cigarette/cigar
+
+/datum/gear/cigarettes
+	display_name = "cigarette selection"
+	path = /obj/item/weapon/storage/fancy/cigarettes
+
+/datum/gear/cigarettes/New()
+	..()
+	var/list/cigarettes = list()
+	for(var/cigarette in (typesof(/obj/item/weapon/storage/fancy/cigarettes) - typesof(/obj/item/weapon/storage/fancy/cigarettes/killthroat)))
+		var/obj/item/weapon/storage/fancy/cigarettes/cigarette_brand = cigarette
+		cigarettes[initial(cigarette_brand.name)] = cigarette_brand
+	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(cigarettes))

--- a/code/modules/client/preference_setup/loadout/loadout_uniform.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_uniform.dm
@@ -235,4 +235,60 @@
 	display_name = "cut top, red"
 	path = /obj/item/clothing/under/cuttop/red
 
+/datum/gear/uniform/colonist1
+	display_name= "colonist clothes"
+	path = /obj/item/clothing/under/colonist
+
+/datum/gear/uniform/colonist2
+	display_name= "colonist clothes, alt"
+	path = /obj/item/clothing/under/colonist/colonist2
+
+/datum/gear/uniform/colonist3
+	display_name= "colonist clothes, alt 2"
+	path = /obj/item/clothing/under/colonist/colonist3
+
+/datum/gear/uniform/tenpenny
+	display_name= "red fancy suit"
+	path = /obj/item/clothing/under/tenpenny
+
+/datum/gear/uniform/springm
+	display_name= "springwear clothes"
+	path = /obj/item/clothing/under/springm
+
+/datum/gear/uniform/relaxedwearm
+	display_name= "relaxedwear"
+	path = /obj/item/clothing/under/relaxedwearm
+
+/datum/gear/uniform/springf
+	display_name= "springwear dress"
+	path = /obj/item/clothing/under/springf
+
+/datum/gear/uniform/wasteland
+	display_name= "wasteland fatigues"
+	path = /obj/item/clothing/under/wasteland
+
+/datum/gear/uniform/cowboy_dark
+	display_name= "black cowboy outfit"
+	path = /obj/item/clothing/under/cowboy_dark
+
+/datum/gear/uniform/cowboy
+	display_name= "brown cowboy outfit"
+	path = /obj/item/clothing/under/cowboy
+
+/datum/gear/uniform/seifuku
+	display_name= "delinquent schoolgirl uniform"
+	path = /obj/item/clothing/under/seifuku
+
+/datum/gear/uniform/polkaskirt
+	display_name= "polkadot skirt"
+	path = /obj/item/clothing/under/polkaskirt
+
+/datum/gear/uniform/victoria
+	display_name= "victorian suit"
+	path = /obj/item/clothing/under/victoria
+
+/datum/gear/uniform/girlwinter
+	display_name= "winter girls clothes"
+	path = /obj/item/clothing/under/girlwinter
+
 //EROS FINISH

--- a/code/modules/eros/mob/new_player/sprite_accesories.dm
+++ b/code/modules/eros/mob/new_player/sprite_accesories.dm
@@ -42,6 +42,11 @@
 	longemo
 		name = "Long Emo"
 		icon_state = "hair_emolong"
+
+	fringeemo
+		name = "Emo Fringe"
+		icon_state = "hair_emofringe"
+
 /*
 ///////////////////////////////////
 /  =---------------------------=  /


### PR DESCRIPTION
Baycode uses a 0.9 tickrate, but we use a 0.4 tickrate. This causes, among other things, the procs for regulating body temperature to be called more often than it should be.

Through trial and error/tetsing I found the proper values that return heat transfer to reasonable values. I buffed the cryos to be 25% stronger. 

Cryo:
-heat transfer fix
-buff to gas coolers

Misc:
-Re-adds cigar/cigarette selection to general loadout
-Re-adds emo fringe hair
-Re-adds colonist clothes
-Re-adds red fancy suit
-Re-adds springwear clothes
-Re-adds relaxedwear
-Re-adds wasteland fatigues
-Re-adds cowboy outfits
-Re-adds delinquent schoolgirl uniform
-Re-adds polkadot skirt
-Re-adds victorian suit
-Re-adds winter girls clothes

EDIT:
-Also fixes a small grammar mistake in NT aggressive lawset
