### PR TITLE
Fix the station name text for random events

### DIFF
--- a/maps/exodus/exodus_define.dm
+++ b/maps/exodus/exodus_define.dm
@@ -1,7 +1,7 @@
 
 /datum/map/exodus
-	name = "Exodus"
-	full_name = "NSS Exodus"
+	name = "Eros"
+	full_name = "Eros Research Platform"
 	path = "exodus"
 
 	lobby_icon = 'maps/exodus/exodus_lobby.dmi'


### PR DESCRIPTION
I said on Discord that it bugged me when random events mentioned the "Exodus" when the map is canonically the Eros Research Platform. I'm no coder in Byond, but this seemed like the way to fix it.