### PR TITLE
Glove fixes, take two

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -115,6 +115,16 @@
 	throwforce = 2
 	slot_flags = SLOT_EARS
 	sprite_sheets = list(
+		"Human" = 'icons/mob/ears.dmi',
+		"Machine" = 'icons/mob/ears.dmi',
+		"Drider" = 'icons/mob/ears.dmi',
+		"Lamia" = 'icons/mob/ears.dmi',
+		"Unathi" = 'icons/mob/ears.dmi',
+		"Tajara" = 'icons/mob/ears.dmi',
+		"Skrell" = 'icons/mob/ears.dmi',
+		"Resomi" = 'icons/mob/species/resomi/ears.dmi',
+		"Akula" = 'icons/mob/ears.dmi',
+		"Slime" = 'icons/mob/ears.dmi'
 		"Resomi" = 'icons/mob/species/resomi/ears.dmi',
 		"Human" = 'icons/mob/ears.dmi'
 		)
@@ -180,6 +190,16 @@ BLIND     // can't see anything
 	var/darkness_view = 0//Base human is 2
 	var/see_invisible = -1
 	sprite_sheets = list(
+		"Human" = 'icons/mob/eyes.dmi',
+		"Machine" = 'icons/mob/eyes.dmi',
+		"Drider" = 'icons/mob/eyes.dmi',
+		"Lamia" = 'icons/mob/eyes.dmi',
+		"Unathi" = 'icons/mob/eyes.dmi',
+		"Tajara" = 'icons/mob/eyes.dmi',
+		"Skrell" = 'icons/mob/eyes.dmi',
+		"Resomi" = 'icons/mob/species/resomi/eyes.dmi',
+		"Akula" = 'icons/mob/eyes.dmi',
+		"Slime" = 'icons/mob/eyes.dmi'
 		"Vox" = 'icons/mob/species/vox/eyes.dmi',
 		"Resomi" = 'icons/mob/species/resomi/eyes.dmi',
 		"Human" = 'icons/mob/eyes.dmi'
@@ -214,6 +234,17 @@ BLIND     // can't see anything
 	attack_verb = list("challenged")
 	species_restricted = list("exclude","Unathi","Tajara", "Vox")
 	sprite_sheets = list(
+		"Human" = 'icons/mob/hands.dmi',
+		"Machine" = 'icons/mob/hands.dmi',
+		"Drider" = 'icons/mob/hands.dmi',
+		"Lamia" = 'icons/mob/hands.dmi',
+		"Unathi" = 'icons/mob/hands.dmi',
+		"Tajara" = 'icons/mob/hands.dmi',
+		"Skrell" = 'icons/mob/hands.dmi',
+		"Resomi" = 'icons/mob/species/resomi/gloves.dmi',
+		"Akula" = 'icons/mob/hands.dmi',
+		"Slime" = 'icons/mob/hands.dmi',
+		"Vox" = 'icons/mob/species/vox/gloves.dmi'
 		"Vox" = 'icons/mob/species/vox/gloves.dmi',
 		"Resomi" = 'icons/mob/species/resomi/gloves.dmi',
 		"Human" = 'icons/mob/hands.dmi'
@@ -283,6 +314,16 @@ BLIND     // can't see anything
 	var/on = 0
 	sprite_sheets = list(
 		"Human" = 'icons/mob/head.dmi',
+		"Machine" = 'icons/mob/head.dmi',
+		"Drider" = 'icons/mob/head.dmi',
+		"Lamia" = 'icons/mob/head.dmi',
+		"Unathi" = 'icons/mob/head.dmi',
+		"Tajara" = 'icons/mob/head.dmi',
+		"Skrell" = 'icons/mob/head.dmi',
+		"Resomi" = 'icons/mob/species/resomi/head.dmi',
+		"Akula" = 'icons/mob/head.dmi',
+		"Slime" = 'icons/mob/head.dmi',
+		"Vox" = 'icons/mob/species/vox/head.dmi'
 		"Vox" = 'icons/mob/species/vox/head.dmi',
 		"Resomi" = 'icons/mob/species/resomi/head.dmi'
 		)
@@ -394,6 +435,17 @@ BLIND     // can't see anything
 	slot_flags = SLOT_MASK
 	body_parts_covered = FACE|EYES
 	sprite_sheets = list(
+		"Human" = 'icons/mob/mask.dmi',
+		"Machine" = 'icons/mob/mask.dmi',
+		"Drider" = 'icons/mob/mask.dmi',
+		"Lamia" = 'icons/mob/mask.dmi',
+		"Unathi" = 'icons/mob/species/unathi/mask.dmi',
+		"Tajara" = 'icons/mob/species/tajaran/mask.dmi',
+		"Skrell" = 'icons/mob/mask.dmi',
+		"Resomi" = 'icons/mob/species/resomi/masks.dmi',
+		"Akula" = 'icons/mob/species/akula/mask.dmi',
+		"Slime" = 'icons/mob/mask.dmi',
+		"Vox" = 'icons/mob/species/vox/masks.dmi'
 		"Vox" = 'icons/mob/species/vox/masks.dmi',
 		"Resomi" = 'icons/mob/species/resomi/masks.dmi',
 		"Human" = 'icons/mob/mask.dmi'
@@ -439,6 +491,17 @@ BLIND     // can't see anything
 	var/overshoes = 0
 	species_restricted = list("exclude","Vox")
 	sprite_sheets = list(
+		"Human" = 'icons/mob/feet.dmi',
+		"Machine" = 'icons/mob/feet.dmi',
+		"Drider" = 'icons/mob/feet.dmi',
+		"Lamia" = 'icons/mob/feet.dmi',
+		"Unathi" = 'icons/mob/feet.dmi',
+		"Tajara" = 'icons/mob/feet.dmi',
+		"Skrell" = 'icons/mob/feet.dmi',
+		"Resomi" = 'icons/mob/species/resomi/shoes.dmi',
+		"Akula" = 'icons/mob/feet.dmi',
+		"Slime" = 'icons/mob/feet.dmi',
+		"Vox" = 'icons/mob/species/vox/shoes.dmi'
 		"Vox" = 'icons/mob/species/vox/shoes.dmi',
 		"Resomi" = 'icons/mob/species/resomi/shoes.dmi',
 		"Human" = 'icons/mob/feet.dmi'
@@ -518,6 +581,13 @@ BLIND     // can't see anything
 	w_class = ITEM_SIZE_NORMAL
 
 	sprite_sheets = list(
+		"Human" = 'icons/mob/suit.dmi',
+		"Machine" = 'icons/mob/suit.dmi',
+		"Drider" = 'icons/mob/suit.dmi',
+		"Lamia" = 'icons/mob/suit.dmi',
+		"Unathi" = 'icons/mob/species/unathi/suit.dmi',
+		"Tajara" = 'icons/mob/species/tajaran/suit.dmi',
+		"Skrell" = 'icons/mob/species/skrell/suit.dmi',
 		"Vox" = 'icons/mob/species/vox/suit.dmi',
 		"Resomi" = 'icons/mob/species/resomi/suit.dmi',
 		"Human" = 'icons/mob/suit.dmi'
@@ -565,6 +635,17 @@ BLIND     // can't see anything
 	var/rolled_down = -1 //0 = unrolled, 1 = rolled, -1 = cannot be toggled
 	var/rolled_sleeves = -1 //0 = unrolled, 1 = rolled, -1 = cannot be toggled
 	sprite_sheets = list(
+		"Human" = 'icons/mob/uniform.dmi',
+		"Machine" = 'icons/mob/uniform.dmi',
+		"Drider" = 'icons/mob/uniform.dmi',
+		"Lamia" = 'icons/mob/uniform.dmi',
+		"Unathi" = 'icons/mob/uniform.dmi',
+		"Tajara" = 'icons/mob/uniform.dmi',
+		"Skrell" = 'icons/mob/uniform.dmi',
+		"Resomi" = 'icons/mob/species/resomi/uniform.dmi',
+		"Akula" = 'icons/mob/uniform.dmi',
+		"Slime" = 'icons/mob/uniform.dmi',
+		"Vox" = 'icons/mob/species/vox/uniform.dmi'
 		"Vox" = 'icons/mob/species/vox/uniform.dmi',
 		"Resomi" = 'icons/mob/species/resomi/uniform.dmi',
 		"Human" = 'icons/mob/uniform.dmi'

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -199,7 +199,7 @@ BLIND     // can't see anything
 		"Skrell" = 'icons/mob/eyes.dmi',
 		"Resomi" = 'icons/mob/species/resomi/eyes.dmi',
 		"Akula" = 'icons/mob/eyes.dmi',
-		"Slime" = 'icons/mob/eyes.dmi'
+		"Slime" = 'icons/mob/eyes.dmi',
 		"Vox" = 'icons/mob/species/vox/eyes.dmi',
 		"Resomi" = 'icons/mob/species/resomi/eyes.dmi',
 		"Human" = 'icons/mob/eyes.dmi'
@@ -244,7 +244,7 @@ BLIND     // can't see anything
 		"Resomi" = 'icons/mob/species/resomi/gloves.dmi',
 		"Akula" = 'icons/mob/hands.dmi',
 		"Slime" = 'icons/mob/hands.dmi',
-		"Vox" = 'icons/mob/species/vox/gloves.dmi'
+		"Vox" = 'icons/mob/species/vox/gloves.dmi',
 		"Vox" = 'icons/mob/species/vox/gloves.dmi',
 		"Resomi" = 'icons/mob/species/resomi/gloves.dmi',
 		"Human" = 'icons/mob/hands.dmi'
@@ -323,7 +323,7 @@ BLIND     // can't see anything
 		"Resomi" = 'icons/mob/species/resomi/head.dmi',
 		"Akula" = 'icons/mob/head.dmi',
 		"Slime" = 'icons/mob/head.dmi',
-		"Vox" = 'icons/mob/species/vox/head.dmi'
+		"Vox" = 'icons/mob/species/vox/head.dmi',
 		"Vox" = 'icons/mob/species/vox/head.dmi',
 		"Resomi" = 'icons/mob/species/resomi/head.dmi'
 		)
@@ -445,7 +445,7 @@ BLIND     // can't see anything
 		"Resomi" = 'icons/mob/species/resomi/masks.dmi',
 		"Akula" = 'icons/mob/species/akula/mask.dmi',
 		"Slime" = 'icons/mob/mask.dmi',
-		"Vox" = 'icons/mob/species/vox/masks.dmi'
+		"Vox" = 'icons/mob/species/vox/masks.dmi',
 		"Vox" = 'icons/mob/species/vox/masks.dmi',
 		"Resomi" = 'icons/mob/species/resomi/masks.dmi',
 		"Human" = 'icons/mob/mask.dmi'
@@ -501,7 +501,7 @@ BLIND     // can't see anything
 		"Resomi" = 'icons/mob/species/resomi/shoes.dmi',
 		"Akula" = 'icons/mob/feet.dmi',
 		"Slime" = 'icons/mob/feet.dmi',
-		"Vox" = 'icons/mob/species/vox/shoes.dmi'
+		"Vox" = 'icons/mob/species/vox/shoes.dmi',
 		"Vox" = 'icons/mob/species/vox/shoes.dmi',
 		"Resomi" = 'icons/mob/species/resomi/shoes.dmi',
 		"Human" = 'icons/mob/feet.dmi'
@@ -645,7 +645,7 @@ BLIND     // can't see anything
 		"Resomi" = 'icons/mob/species/resomi/uniform.dmi',
 		"Akula" = 'icons/mob/uniform.dmi',
 		"Slime" = 'icons/mob/uniform.dmi',
-		"Vox" = 'icons/mob/species/vox/uniform.dmi'
+		"Vox" = 'icons/mob/species/vox/uniform.dmi',
 		"Vox" = 'icons/mob/species/vox/uniform.dmi',
 		"Resomi" = 'icons/mob/species/resomi/uniform.dmi',
 		"Human" = 'icons/mob/uniform.dmi'

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -124,7 +124,7 @@
 		"Skrell" = 'icons/mob/ears.dmi',
 		"Resomi" = 'icons/mob/species/resomi/ears.dmi',
 		"Akula" = 'icons/mob/ears.dmi',
-		"Slime" = 'icons/mob/ears.dmi'
+		"Slime" = 'icons/mob/ears.dmi',
 		"Resomi" = 'icons/mob/species/resomi/ears.dmi',
 		"Human" = 'icons/mob/ears.dmi'
 		)


### PR DESCRIPTION
ON the tin. Forces the sprite sheet for most races so that it overrides
the error in the layering issue. Currently working with Baystation
admins to try to solve that, this is just a bandaid.