### PR TITLE
Ninja Tweaks

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/computer.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/computer.dm
@@ -367,7 +367,7 @@
 	var/atom/interfaced_with // Currently draining power from this device.
 	var/total_power_drained = 0
 	var/drain_loc
-	var/max_draining_rate = 120 KILOWATTS // The same as unupgraded cyborg recharger.
+	var/max_draining_rate = 600 KILOWATTS // The same as unupgraded cyborg recharger.
 
 /obj/item/rig_module/power_sink/deactivate()
 

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -16,8 +16,8 @@
 	disruptable = 1
 	disruptive = 0
 
-	use_power_cost = 5 KILOWATTS
-	active_power_cost = 500
+	use_power_cost = 150 KILOWATTS
+	active_power_cost = 50 KILOWATTS
 	passive_power_cost = 0
 	module_cooldown = 30
 
@@ -69,7 +69,7 @@
 	name = "teleportation module"
 	desc = "A complex, sleek-looking, hardsuit-integrated teleportation module."
 	icon_state = "teleporter"
-	use_power_cost = 25 KILOWATTS
+	use_power_cost = 500 KILOWATTS
 	redundant = 1
 	usable = 1
 	selectable = 1


### PR DESCRIPTION
Tweaks ninja power usages.

The cloak now only lasts ~60 seconds, with an increased cost to activate. 

Teleport is also vastly increased, to have about ~10 teleports from a full charge.

The power sink has been buffed greatly, about five times quicker to recharge your battery. 