### PR TITLE
Changes so feral species don't need shoes

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -37,6 +37,9 @@
 				tally += I.slowdown_general
 				tally += I.slowdown_per_slot[slot]
 
+		if(species.can_run_shoeless && !shoes)
+			tally += SHOES_SLOWDOWN
+
 		var/list/stance_limbs = get_stance_limbs()
 		for(var/obj/item/organ/external/E in stance_limbs)
 			// The () conditionals after += cover variable-amount limbs; if they only have 1 "standing" limb instead of the normal 4, they get 4 times as much damage

--- a/code/modules/mob/living/carbon/human/species/outsider/shadow.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/shadow.dm
@@ -11,6 +11,7 @@
 	darksight = 8
 	has_organ = list()
 	siemens_coefficient = 0
+	can_run_shoeless = 1
 
 	blood_color = "#CCCCCC"
 	flesh_color = "#AAAAAA"

--- a/code/modules/mob/living/carbon/human/species/outsider/vox.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/vox.dm
@@ -23,6 +23,7 @@
 
 	warning_low_pressure = 50
 	hazard_low_pressure = 0
+	can_run_shoeless = 1
 
 	cold_level_1 = 80
 	cold_level_2 = 50
@@ -101,6 +102,7 @@
 	rarity_value = 0.1
 	speech_chance = 60        // No volume control.
 	siemens_coefficient = 0.5 // Ragged scaleless patches.
+	can_run_shoeless = 1
 
 	oxy_mod = 1.4
 	brute_mod = 1.3

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -98,6 +98,7 @@
 	var/warning_low_pressure = WARNING_LOW_PRESSURE   // Low pressure warning.
 	var/hazard_low_pressure = HAZARD_LOW_PRESSURE     // Dangerously low pressure.
 	var/light_dam                                     // If set, mob will be damaged in light over this value and heal in light below its negative.
+	var/can_run_shoeless = 0                          // If true, this mob doesn't need shoes to maintain running speed
 	var/body_temperature = 310.15	                  // Species will try to stabilize at this temperature.
 	                                                  // (also affects temperature processing)
 

--- a/code/modules/mob/living/carbon/human/species/station/golem.dm
+++ b/code/modules/mob/living/carbon/human/species/station/golem.dm
@@ -10,6 +10,7 @@
 	flags = NO_PAIN | NO_SCAN | NO_POISON
 	spawn_flags = SPECIES_IS_RESTRICTED
 	siemens_coefficient = 0
+	can_run_shoeless = 1
 
 	breath_type = null
 	poison_type = null

--- a/code/modules/mob/living/carbon/human/species/station/machine.dm
+++ b/code/modules/mob/living/carbon/human/species/station/machine.dm
@@ -16,6 +16,7 @@
 	rarity_value = 2
 	num_alternate_languages = 2
 	name_language = LANGUAGE_EAL
+	can_run_shoeless = 1
 
 	min_age = 18
 	max_age = 90
@@ -38,7 +39,7 @@
 	passive_temp_gain = 1  // This should cause IPCs to stabilize at ~80 C in a 20 C environment.
 
 	flags = NO_SCAN | NO_PAIN | NO_POISON
-	spawn_flags = SPECIES_CAN_JOIN 
+	spawn_flags = SPECIES_CAN_JOIN
 	appearance_flags = HAS_UNDERWEAR | HAS_BIOMODS | HAS_HAIR_COLOR | HAS_SKIN_COLOR //IPCs can wear undies too :(
 
 	blood_color = "#1F181F"

--- a/code/modules/mob/living/carbon/human/species/station/resomi.dm
+++ b/code/modules/mob/living/carbon/human/species/station/resomi.dm
@@ -13,6 +13,7 @@
 	min_age = 18
 	max_age = 65
 	health_hud_intensity = 3
+	can_run_shoeless = 1
 
 	blood_color = "#D514F7"
 	flesh_color = "#5F7BB0"
@@ -39,7 +40,7 @@
 	blood_volume = 280
 	hunger_factor = 0.2
 
-	spawn_flags = SPECIES_CAN_JOIN 
+	spawn_flags = SPECIES_CAN_JOIN
 	appearance_flags = HAS_HAIR_COLOR | HAS_SKIN_COLOR | HAS_EYE_COLOR | HAS_BIOMODS
 	bump_flag = MONKEY
 	swap_flags = MONKEY|SLIME|SIMPLE_ANIMAL

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -37,6 +37,7 @@
 	secondary_langs = list(LANGUAGE_UNATHI)
 	name_language = LANGUAGE_UNATHI
 	health_hud_intensity = 2
+	can_run_shoeless = 1
 
 	min_age = 18
 	max_age = 60
@@ -100,6 +101,7 @@
 	secondary_langs = list(LANGUAGE_SIIK_MAAS, LANGUAGE_SIIK_TAJR)
 	name_language = LANGUAGE_SIIK_MAAS
 	health_hud_intensity = 1.75
+	can_run_shoeless = 1
 
 	min_age = 18
 	max_age = 80
@@ -212,6 +214,7 @@
 	name_language = LANGUAGE_ROOTLOCAL
 	spawns_with_stack = 0
 	health_hud_intensity = 2
+	can_run_shoeless = 1 //Don't need shoes because technically just a bunch of roots, but still slower than christmas
 
 	min_age = 1
 	max_age = 300
@@ -325,6 +328,7 @@
 	min_age = 18
 	max_age = 110
 	slowdown = - 0.5
+	can_run_shoeless = 1 //Danger noodles don't need shoes
 
 	gluttonous = GLUT_ANYTHING // They eat people! But don't qdel the corpses, and can only carry one at a time.
 	stomach_capacity = MOB_MEDIUM
@@ -367,6 +371,7 @@
 	max_age = 110
 	slowdown = - 0.5
 	toxins_mod = 0.25
+	can_run_shoeless = 1 //You need how many shoes again?
 
 	gluttonous = GLUT_SMALLER // They eat smaller creatures.
 	stomach_capacity = MOB_SMALL

--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
@@ -14,6 +14,7 @@
 	siemens_coefficient = 0
 	gluttonous = GLUT_ANYTHING|GLUT_QDEL_MOBS
 	stomach_capacity = MOB_MEDIUM
+	can_run_shoeless = 1
 
 	brute_mod = 0.25 // Hardened carapace.
 	burn_mod = 1.1    // Weak to fire.


### PR DESCRIPTION
Resomi, Unathi, Tajara, Vox, Lamia and Driders now move as if they had shoes on regardless of whether or not they really do, gaining the boost from SHOES_SLOWDOWN if they're without shoes due to their more feral, animal-like feet. Diona also get this perk due to being a mass of plantlife instead of a creature, but it's so un-noticable on them it may as well not matter. Shadows also get this for similar reasons of being esoteric in nature.

Prometheans, Humans, Skrell and Akula all have too soft, sensitive, or sticky of feet to gain such a perk though, as sprinting all out on metal tile probably wouldn't be too comfortable. (Especially since Akula and Skrell both have webbed or at least weird feet)