### PR TITLE
Two quick Resomi tweaks

### DIFF
--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -19,7 +19,7 @@
 
 	minimal_player_age = 14
 	ideal_character_age = 50
-	species_restricted = list("Tajara", "Vox", "Resomi", "Diona")
+	species_restricted = list("Tajara", "Vox", "Diona")
 	outfit_type = /decl/hierarchy/outfit/job/medical/cmo
 
 /datum/job/doctor

--- a/code/modules/mob/living/carbon/human/species/station/resomi.dm
+++ b/code/modules/mob/living/carbon/human/species/station/resomi.dm
@@ -5,7 +5,7 @@
 	outside of the Goldilocks zone. Extremely fragile, they developed hunting skills \
 	that emphasized taking out their prey without themselves getting hit. They are an \
 	advanced culture on good terms with Skrellian and Human interests.\
-	Resomi are not permitted to be CMO, HoS, or Captain."
+	Resomi are not permitted to be HoS or Captain."
 
 	num_alternate_languages = 2
 	secondary_langs = list(LANGUAGE_RESOMI)

--- a/code/modules/mob/living/carbon/human/species/station/resomi.dm
+++ b/code/modules/mob/living/carbon/human/species/station/resomi.dm
@@ -10,8 +10,8 @@
 	num_alternate_languages = 2
 	secondary_langs = list(LANGUAGE_RESOMI)
 	name_language = LANGUAGE_RESOMI
-	min_age = 18
-	max_age = 65
+	min_age = 12
+	max_age = 60
 	health_hud_intensity = 3
 	can_run_shoeless = 1
 


### PR DESCRIPTION
Basically what it says on the tin. 

Resomi can CMO now since I'd not heard any clear reason given for why they were restricted on that. (Leftover from Teshari?)

Also, in talking with the former loremaster for Resomi, Aticius, I found out our minimum and maximum ages were wrong; little birds age quicker and die faster. Minimum is now 12, the absolute youngest working age, and maximum is 60, which is the average lifespan without regenerative cloning or the nano tech that's keeping the leaders of A'neech alive.